### PR TITLE
fix: update addrs after TOB-10/16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- update addresses after tob-16 changes
 - index `DepositCompleted` and `DepositRetrieved` events, and use them to update `DepositRequest` `status`.
 - add `DepositRequest` entity
 - add `SDKEvent` and `TreeInsertionEvent` types that unify events that SDK / subtree updater cares about

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -7,7 +7,7 @@ dataSources:
     network: mainnet
     source:
       abi: Handler
-      address: "0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6"
+      address: "0x0165878A594ca255338adfa4d48449f69242Eb8F"
       startBlock: 0
     mapping:
       kind: ethereum/events
@@ -41,7 +41,7 @@ dataSources:
     network: mainnet
     source:
       abi: DepositManager
-      address: "0x0B306BF915C4d645ff596e518fAf3F9669b97016"
+      address: "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82"
       startBlock: 0
     mapping:
       kind: ethereum/events


### PR DESCRIPTION
TOB-10/16 removes erc721//1155 from handler and 721//1155 tokens everywhere. Update contract addrs now that we don't deploy erc721/1155 tokens.