### PR TITLE
fix: change deposit request typehash after TOB-5

### DIFF
--- a/src/eip712Hash.ts
+++ b/src/eip712Hash.ts
@@ -1,6 +1,6 @@
 import { Address, BigInt, Bytes, ethereum, crypto } from "@graphprotocol/graph-ts";
 
-export const DEPOSIT_REQUEST_TYPEHASH = Bytes.fromHexString("0x855afe7344d18c4bdc83e30bd3b96d1c7beb1f1f82b864a7a6004d77f974bbde");
+export const DEPOSIT_REQUEST_TYPEHASH = Bytes.fromHexString("0x9a8b76499925b1382e5e342faa019bad779d0900dfd40b53118a03adf205a6a3");
 export const ENCODED_ASSET_TYPEHASH = Bytes.fromHexString("0xa707f92ebe5bcecfbef399229bf3acedaf435815f572a1f2a716607a200753ae");
 export const STEALTH_ADDRESS_TYPEHASH = Bytes.fromHexString("0x0b8fd92970709e094f6461cb1a258bc5dad96431ceac3635ba90da7e52b8b9db");
 


### PR DESCRIPTION
Deposit request typehash changed due to alphabetical reordering. Made consistent here.