### PR TITLE
fix typo in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - rename `subtreeIndex` in tree insertion entities to `subtreeBatchOffset`
 - add tree insertion events
 - store entity id in bigint form in new field `idx` for every entity
-- add `mainnet` (which actually points to locahost) to `networks.json`
+- add `mainnet` (which actually points to localhost) to `networks.json`
   - TODO: figure out how to differentiate between locally-deployed mainnet and actual mainnet in config
 - update ABI after renaming wallet to teller
 - update ABI after adding encrypted sender addr to joinsplit struct


### PR DESCRIPTION
fix typo in `CHANGELOG.md`: locahost->localhost